### PR TITLE
fix(core): Client router error control flow

### DIFF
--- a/packages/core/src/client/router.ts
+++ b/packages/core/src/client/router.ts
@@ -35,8 +35,7 @@ window?.addEventListener('popstate', (event: PopStateEvent) => {
     const html = sessionStorage?.getItem(`prpl-${url}`);
 
     if (!html) {
-      window?.location?.assign(url);
-      console.info('[PRPL] Routing natively. Reason:', `No cached html for route ${url}`);
+      throw new Error(`No cached html for route ${url}`);
     }
 
     const parser = new DOMParser();


### PR DESCRIPTION
End script execution and route natively if no cached html is found for a page during navigation attempt.