### PR TITLE
Feat introduce indexed db for durable storage

### DIFF
--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -209,7 +209,8 @@ import { interpolate } from '@prpl/core';
 const options = {
   noClientJS: false,
   templateRegex: (key) => new RegExp(`\\[${key}\\]`, 'g'),
-  markedOptions: {}
+  markedOptions: {},
+  buildId: Date.now()
 };
 
 async function build() {
@@ -226,6 +227,7 @@ build();
   your preference
 - `markedOptions` are options you can pass to [`marked`](https://marked.js.org/using_advanced#options), the only
   dependency of `@prpl/core`
+- `buildId` is an identifier used for invalidation of your site's IndexedDB cache. It should be unique to each build
 
 ## Events
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -9,18 +9,21 @@
       "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@types/marked": "^4.0.2",
         "idb-keyval": "^6.1.0",
         "marked": "^4.0.12"
       },
       "bin": {
         "prpl": "bin/prpl.js"
+      },
+      "devDependencies": {
+        "@types/marked": "^4.0.2"
       }
     },
     "node_modules/@types/marked": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.2.tgz",
-      "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ=="
+      "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ==",
+      "dev": true
     },
     "node_modules/idb-keyval": {
       "version": "6.1.0",
@@ -51,7 +54,8 @@
     "@types/marked": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.2.tgz",
-      "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ=="
+      "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ==",
+      "dev": true
     },
     "idb-keyval": {
       "version": "6.1.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "@prpl/core",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@types/marked": "^4.0.2",
+        "idb-keyval": "^6.1.0",
         "marked": "^4.0.12"
       },
       "bin": {
@@ -21,6 +22,14 @@
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.2.tgz",
       "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ=="
     },
+    "node_modules/idb-keyval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.1.0.tgz",
+      "integrity": "sha512-u/qHZ75rlD3gH+Zah8dAJVJcGW/RfCnfNrFkElC5RpRCnpsCXXhqjVk+6MoVKJ3WhmNbRYdI6IIVP88e+5sxGw==",
+      "dependencies": {
+        "safari-14-idb-fix": "^3.0.0"
+      }
+    },
     "node_modules/marked": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
@@ -31,6 +40,11 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/safari-14-idb-fix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     }
   },
   "dependencies": {
@@ -39,10 +53,23 @@
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.2.tgz",
       "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ=="
     },
+    "idb-keyval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.1.0.tgz",
+      "integrity": "sha512-u/qHZ75rlD3gH+Zah8dAJVJcGW/RfCnfNrFkElC5RpRCnpsCXXhqjVk+6MoVKJ3WhmNbRYdI6IIVP88e+5sxGw==",
+      "requires": {
+        "safari-14-idb-fix": "^3.0.0"
+      }
+    },
     "marked": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
       "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
+    },
+    "safari-14-idb-fix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,9 +32,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@types/marked": "^4.0.2",
     "idb-keyval": "^6.1.0",
     "marked": "^4.0.12"
   },
-  "gitHead": "57646bee5e16c078b43aa2de487372464594de1c"
+  "gitHead": "57646bee5e16c078b43aa2de487372464594de1c",
+  "devDependencies": {
+    "@types/marked": "^4.0.2"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/marked": "^4.0.2",
+    "idb-keyval": "^6.1.0",
     "marked": "^4.0.12"
   },
   "gitHead": "57646bee5e16c078b43aa2de487372464594de1c"

--- a/packages/core/src/client/prefetch.ts
+++ b/packages/core/src/client/prefetch.ts
@@ -11,7 +11,7 @@ function getPaths(): string[] {
 }
 
 function getPRPLBuildId(): string {
-  return document.querySelector('meta[prpl-build-id]').getAttribute('prpl-build-id');
+  return document.querySelector('meta[name="prpl-build-id"]')?.getAttribute('content');
 }
 
 if (window.Worker) {

--- a/packages/core/src/client/prefetch.ts
+++ b/packages/core/src/client/prefetch.ts
@@ -1,16 +1,17 @@
 import { PRPLClientEvent } from '../types/prpl.js';
 
-/**
- * Collect unique relative anchor hrefs on the current page.
- */
-function getRelativePaths(): string[] {
-  // TODO - Define more granular definition of which anchor tags the PRPL prefetch worker should to try to fetch
+// TODO - Define more granular definition of which anchor tags the PRPL prefetch worker should to try to fetch
+function getPaths(): string[] {
   const relativePaths: string[] = [
     ...Array.from(document?.querySelectorAll('a:not([rel])'))
       .filter((link) => (link as HTMLAnchorElement)?.href?.includes(window?.location?.origin))
       .map((link) => (link as HTMLAnchorElement)?.href)
   ];
-  return Array.from(new Set(relativePaths));
+  return [window?.location?.href, ...Array.from(new Set(relativePaths))];
+}
+
+function getPRPLBuildId(): string {
+  return document.querySelector('meta[prpl-build-id]').getAttribute('prpl-build-id');
 }
 
 if (window.Worker) {
@@ -18,12 +19,18 @@ if (window.Worker) {
   const prefetchWorker = new Worker('prefetch-worker.js', { type: 'module' });
 
   // Initial optional prefetch of on page links
-  prefetchWorker?.postMessage([window?.location?.href, ...getRelativePaths()]);
+  prefetchWorker?.postMessage({
+    paths: getPaths(),
+    buildId: getPRPLBuildId()
+  });
 
   // Subsequent prefetches on page render
   window.addEventListener(PRPLClientEvent.render, () => {
     try {
-      prefetchWorker?.postMessage([window?.location?.href, ...getRelativePaths()]);
+      prefetchWorker?.postMessage({
+        paths: getPaths(),
+        buildId: getPRPLBuildId()
+      });
     } catch (error) {
       console.info('[PRPL] Failed to prefetch on subsequent page route. Error:', error);
     }

--- a/packages/core/src/client/router.ts
+++ b/packages/core/src/client/router.ts
@@ -122,5 +122,5 @@ function onClick(event: MouseEvent): void {
   }
 }
 
-document?.addEventListener('click', onClick);
-window?.addEventListener('popstate', onPopState);
+document?.addEventListener('click', (event: MouseEvent) => onClick(event));
+window?.addEventListener('popstate', (event: PopStateEvent) => onPopState(event));

--- a/packages/core/src/client/router.ts
+++ b/packages/core/src/client/router.ts
@@ -1,9 +1,7 @@
+import { get } from 'idb-keyval';
 import { PRPLClientEvent, PRPLClientScript, PRPLClientPerformanceMark } from '../types/prpl.js';
 
-/**
- * Helper function to extract a CSS attribute query.
- */
-function extractQuery(tag: HTMLElement): string {
+function extractAttributeQuery(tag: HTMLElement): string {
   const name = tag?.tagName?.toLowerCase();
   let attrQueries = '';
   for (let i = 0; i < tag?.attributes?.length; i++) {
@@ -13,10 +11,7 @@ function extractQuery(tag: HTMLElement): string {
   return `${name}${attrQueries}`;
 }
 
-/**
- * Helper function to determine if the script should be ignored during diff.
- */
-function ignoreScript(script: HTMLHeadElement): boolean {
+function isPRPLScript(script: HTMLHeadElement): boolean {
   if (script?.tagName?.toLowerCase() !== 'script') {
     return;
   }
@@ -27,79 +22,86 @@ function ignoreScript(script: HTMLHeadElement): boolean {
   );
 }
 
-window?.addEventListener('popstate', (event: PopStateEvent) => {
+function constructTargetDocument(html: string): Document {
+  const parser = new DOMParser();
+  const target = parser?.parseFromString(html, 'text/html');
+  return target;
+}
+
+function diffDOM(target: Document): void {
+  // Swap main
+  const currentMain = document?.querySelector('main');
+  const targetMain = target?.querySelector('main');
+  currentMain?.replaceWith(targetMain);
+
+  // Diff head
+  const currentHeadTags = Array.from(
+    document?.querySelector('head')?.children
+  ) as HTMLHeadElement[];
+  const targetHeadTags = Array.from(target?.querySelector('head')?.children) as HTMLHeadElement[];
+
+  // Remove head tags
+  currentHeadTags?.forEach((currentHeadTag) => {
+    if (
+      targetHeadTags?.some((targetHeadTag) => targetHeadTag?.isEqualNode(currentHeadTag)) ||
+      isPRPLScript(currentHeadTag)
+    ) {
+      return;
+    }
+    document?.head?.querySelector(extractAttributeQuery(currentHeadTag))?.remove();
+  });
+
+  // Add head tags
+  targetHeadTags?.forEach((targetHeadTag) => {
+    if (
+      currentHeadTags?.some((currentHeadTag) => currentHeadTag?.isEqualNode(targetHeadTag)) ||
+      isPRPLScript(targetHeadTag)
+    ) {
+      return;
+    }
+    if (targetHeadTag?.tagName?.toLowerCase() === 'script') {
+      const clonedScript = document?.createElement('script');
+      clonedScript.src = (targetHeadTag as HTMLScriptElement)?.src;
+      document?.head?.appendChild(clonedScript);
+      return;
+    }
+    document?.head?.appendChild(targetHeadTag);
+  });
+}
+
+function adjustScroll(targetUrl: string, url: string, hash: string): void {
+  // Scroll to hash if one exists in the url
+  if (hash) {
+    document.getElementById(hash)?.scrollIntoView();
+  }
+
+  // Scroll to top if user clicked a link, otherwise preserve scroll state
+  if (!hash && url === targetUrl) {
+    window?.scrollTo({ top: 0 });
+  }
+}
+
+async function onPopState(event: PopStateEvent): Promise<void> {
   const [url, hash] = window?.location?.href?.split('#') || [];
 
   try {
     const [targetUrl] = event?.state?.url?.split('#') || [];
-    const html = sessionStorage?.getItem(`prpl-${url}`);
-
+    const html = await get(`prpl-${url}`);
     if (!html) {
       throw new Error(`No cached html for route ${url}`);
     }
-
-    const parser = new DOMParser();
-    const target = parser?.parseFromString(html, 'text/html');
-
-    // Swap main
-    const currentMain = document?.querySelector('main');
-    const targetMain = target?.querySelector('main');
-    currentMain?.replaceWith(targetMain);
-
-    // Diff head
-    const currentHeadTags = Array.from(
-      document?.querySelector('head')?.children
-    ) as HTMLHeadElement[];
-    const targetHeadTags = Array.from(target?.querySelector('head')?.children) as HTMLHeadElement[];
-
-    // Remove head tags
-    currentHeadTags?.forEach((currentHeadTag) => {
-      if (
-        targetHeadTags?.some((targetHeadTag) => targetHeadTag?.isEqualNode(currentHeadTag)) ||
-        ignoreScript(currentHeadTag)
-      ) {
-        return;
-      }
-      document?.head?.querySelector(extractQuery(currentHeadTag))?.remove();
-    });
-
-    // Add head tags
-    targetHeadTags?.forEach((targetHeadTag) => {
-      if (
-        currentHeadTags?.some((currentHeadTag) => currentHeadTag?.isEqualNode(targetHeadTag)) ||
-        ignoreScript(targetHeadTag)
-      ) {
-        return;
-      }
-      if (targetHeadTag?.tagName?.toLowerCase() === 'script') {
-        const clonedScript = document?.createElement('script');
-        clonedScript.src = (targetHeadTag as HTMLScriptElement)?.src;
-        document?.head?.appendChild(clonedScript);
-        return;
-      }
-      document?.head?.appendChild(targetHeadTag);
-    });
-
-    // Scroll to hash if one exists in the url
-    if (hash) {
-      document.getElementById(hash)?.scrollIntoView();
-    }
-
-    // Scroll to top if user clicked a link, otherwise preserve scroll state
-    if (!hash && url === targetUrl) {
-      window?.scrollTo({ top: 0 });
-    }
-
-    // Indicate render has finished
+    const target = constructTargetDocument(html);
+    diffDOM(target);
+    adjustScroll(targetUrl, url, hash);
     dispatchEvent(new CustomEvent(PRPLClientEvent.render, { bubbles: true }));
     performance.mark(PRPLClientPerformanceMark.renderEnd);
   } catch (error) {
     window?.location?.assign(url);
     console.info('[PRPL] Routing natively. Reason:', error?.message);
   }
-});
+}
 
-document?.addEventListener('click', (event: MouseEvent) => {
+function onClick(event: MouseEvent): void {
   performance.mark(PRPLClientPerformanceMark.renderStart);
 
   // TODO - Define more granular definition of which anchor tags the PRPL router should try to act on
@@ -118,4 +120,7 @@ document?.addEventListener('click', (event: MouseEvent) => {
       window?.location?.assign(url);
     }
   }
-});
+}
+
+document?.addEventListener('click', onClick);
+window?.addEventListener('popstate', onPopState);

--- a/packages/core/src/interpolate/interpolate-html.ts
+++ b/packages/core/src/interpolate/interpolate-html.ts
@@ -16,14 +16,15 @@ import { interpolateList } from './interpolate-list.js';
 async function interpolateHTML(args: {
   srcTree: PRPLFileSystemTree;
   options?: PRPLInterpolateOptions;
+  buildId?: number;
 }): Promise<void> {
-  const { srcTree, options = {} } = args || {};
+  const { srcTree, options = {}, buildId = Date.now() } = args || {};
 
-  // Add prefetch and router script tags
+  // Inject build id, prefetch and router scripts
   if (!options?.noClientJS) {
     srcTree.src = srcTree?.src?.replace(
       /<\/head>/,
-      `<script type="module" src="prefetch.js"></script>\n<script type="module" src="router.js"></script>\n</head>`
+      `<meta prpl-build-id="${buildId}"></meta>\n<script defer type="module" src="prefetch.js"></script>\n<script defer type="module" src="router.js"></script>\n</head>`
     );
   }
 

--- a/packages/core/src/interpolate/interpolate-html.ts
+++ b/packages/core/src/interpolate/interpolate-html.ts
@@ -23,9 +23,7 @@ async function interpolateHTML(args: {
   if (!options?.noClientJS) {
     srcTree.src = srcTree?.src?.replace(
       /<\/head>/,
-      `<meta name="prpl-build-id" content="${
-        options?.buildId ?? Date.now()
-      }"></meta>\n<script defer type="module" src="prefetch.js"></script>\n<script defer type="module" src="router.js"></script>\n</head>`
+      `<meta name="prpl-build-id" content="${options?.buildId}"></meta>\n<script defer type="module" src="prefetch.js"></script>\n<script defer type="module" src="router.js"></script>\n</head>`
     );
   }
 

--- a/packages/core/src/interpolate/interpolate-html.ts
+++ b/packages/core/src/interpolate/interpolate-html.ts
@@ -16,15 +16,16 @@ import { interpolateList } from './interpolate-list.js';
 async function interpolateHTML(args: {
   srcTree: PRPLFileSystemTree;
   options?: PRPLInterpolateOptions;
-  buildId?: number;
 }): Promise<void> {
-  const { srcTree, options = {}, buildId = Date.now() } = args || {};
+  const { srcTree, options = {} } = args || {};
 
   // Inject build id, prefetch and router scripts
   if (!options?.noClientJS) {
     srcTree.src = srcTree?.src?.replace(
       /<\/head>/,
-      `<meta prpl-build-id="${buildId}"></meta>\n<script defer type="module" src="prefetch.js"></script>\n<script defer type="module" src="router.js"></script>\n</head>`
+      `<meta name="prpl-build-id" content="${
+        options?.buildId ?? Date.now()
+      }"></meta>\n<script defer type="module" src="prefetch.js"></script>\n<script defer type="module" src="router.js"></script>\n</head>`
     );
   }
 

--- a/packages/core/src/interpolate/interpolate.ts
+++ b/packages/core/src/interpolate/interpolate.ts
@@ -15,8 +15,6 @@ import { ensureDir } from '../lib/ensure-dir.js';
 import { interpolateHTML } from './interpolate-html.js';
 import { PRPLCache } from '../lib/cache.js';
 
-const buildId: number = Date.now();
-
 const PRPLClientScripts: PRPLClientScript[] = [
   PRPLClientScript.prefetch,
   PRPLClientScript.prefetchWorker,
@@ -56,7 +54,7 @@ async function interpolate(args?: {
           await ensureDir(items?.[i]?.targetDir);
 
           if (items?.[i]?.extension === PRPLSourceFileExtension.html) {
-            await interpolateHTML({ srcTree: items?.[i], options, buildId });
+            await interpolateHTML({ srcTree: items?.[i], options });
             break;
           }
 

--- a/packages/core/src/interpolate/interpolate.ts
+++ b/packages/core/src/interpolate/interpolate.ts
@@ -29,6 +29,9 @@ async function interpolate(args?: {
 }): Promise<PRPLCacheManager['cache']> {
   const { options = {} } = args || {};
 
+  // Create build id if none exists
+  options.buildId = options?.buildId ?? String(Date.now());
+
   // Make sure dist exists
   await ensureDir(resolve('dist'));
 

--- a/packages/core/src/interpolate/interpolate.ts
+++ b/packages/core/src/interpolate/interpolate.ts
@@ -15,6 +15,8 @@ import { ensureDir } from '../lib/ensure-dir.js';
 import { interpolateHTML } from './interpolate-html.js';
 import { PRPLCache } from '../lib/cache.js';
 
+const buildId: number = Date.now();
+
 const PRPLClientScripts: PRPLClientScript[] = [
   PRPLClientScript.prefetch,
   PRPLClientScript.prefetchWorker,
@@ -54,7 +56,7 @@ async function interpolate(args?: {
           await ensureDir(items?.[i]?.targetDir);
 
           if (items?.[i]?.extension === PRPLSourceFileExtension.html) {
-            await interpolateHTML({ srcTree: items?.[i], options });
+            await interpolateHTML({ srcTree: items?.[i], options, buildId });
             break;
           }
 

--- a/packages/core/src/types/prpl.ts
+++ b/packages/core/src/types/prpl.ts
@@ -89,11 +89,6 @@ export type PRPLAttributes = {
   parsed: PRPLAttributeMap;
 };
 
-export type PRPLClientStorageItem = {
-  storageKey: string;
-  storageValue: string;
-};
-
 export const enum PRPLClientEvent {
   render = 'prpl-render'
 }

--- a/packages/core/src/types/prpl.ts
+++ b/packages/core/src/types/prpl.ts
@@ -102,4 +102,5 @@ export interface PRPLInterpolateOptions {
   noClientJS?: boolean;
   templateRegex?: RegExp | ((key: string) => RegExp | any);
   markedOptions?: marked.MarkedOptions;
+  buildId?: string
 }

--- a/packages/create-prpl/package-lock.json
+++ b/packages/create-prpl/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "create-prpl",
-      "version": "0.0.29",
+      "version": "0.0.32",
       "license": "MIT",
       "bin": {
         "create-prpl": "dist/index.cjs"

--- a/packages/plugin-aws/package-lock.json
+++ b/packages/plugin-aws/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-aws",
-      "version": "0.2.7",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.953.0"

--- a/packages/plugin-cache/package-lock.json
+++ b/packages/plugin-cache/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-cache",
-      "version": "0.2.8",
+      "version": "0.2.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"

--- a/packages/plugin-code-highlight/package-lock.json
+++ b/packages/plugin-code-highlight/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-code-highlight",
-      "version": "0.3.3",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "11.2.0",

--- a/packages/plugin-css-imports/package-lock.json
+++ b/packages/plugin-css-imports/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-css-imports",
-      "version": "0.2.8",
+      "version": "0.2.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"

--- a/packages/plugin-html-imports/package-lock.json
+++ b/packages/plugin-html-imports/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-html-imports",
-      "version": "0.2.8",
+      "version": "0.2.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"

--- a/packages/plugin-rss/package-lock.json
+++ b/packages/plugin-rss/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-rss",
-      "version": "0.2.7",
+      "version": "0.2.10",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"

--- a/packages/plugin-sitemap/package-lock.json
+++ b/packages/plugin-sitemap/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/plugin-sitemap",
-      "version": "0.1.8",
+      "version": "0.1.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@prpl/server",
-      "version": "0.1.7",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",

--- a/rollup-client.config.js
+++ b/rollup-client.config.js
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import typescript from 'rollup-plugin-typescript2';
 import analyze from 'rollup-plugin-analyzer';
+import nodeResolve from '@rollup/plugin-node-resolve';
 
 const clientScripts = [
   resolve('packages/core/src/client/prefetch-worker.ts'),
@@ -25,6 +26,7 @@ async function bundle() {
         }
       ],
       plugins: [
+        nodeResolve(),
         typescript({
           tsconfigOverride: {
             compilerOptions: {

--- a/tests/cypress/integration/core.spec.js
+++ b/tests/cypress/integration/core.spec.js
@@ -35,6 +35,21 @@ const misc = {
 const { index, notes } = pages;
 const { a, b } = content;
 
+describe('All pages', () => {
+  it('should have a build id meta tag', () => {
+    cy.visit(index.route);
+    cy.get('meta[name="prpl-build-id"]').invoke('attr', 'content').should('exist');
+
+    // Check existance after DOM diff
+    cy.visit(notes.route);
+    cy.get('meta[name="prpl-build-id"]').invoke('attr', 'content').should('exist');
+
+    // Check existence on other page's actual HTML
+    cy.reload();
+    cy.get('meta[name="prpl-build-id"]').invoke('attr', 'content').should('exist');
+  });
+});
+
 describe('Files without PRPL tags', () => {
   it('should be copied without interpolation', () => {
     cy.visit(index.route);

--- a/tests/test-site/package-lock.json
+++ b/tests/test-site/package-lock.json
@@ -22,19 +22,22 @@
     },
     "../../packages/core": {
       "name": "@prpl/core",
-      "version": "0.2.9",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@types/marked": "^2.0.4",
-        "marked": "^2.1.0"
+        "idb-keyval": "^6.1.0",
+        "marked": "^4.0.12"
       },
       "bin": {
         "prpl": "bin/prpl.js"
+      },
+      "devDependencies": {
+        "@types/marked": "^4.0.2"
       }
     },
     "../../packages/plugin-code-highlight": {
       "name": "@prpl/plugin-code-highlight",
-      "version": "0.3.3",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "11.2.0",
@@ -46,7 +49,7 @@
     },
     "../../packages/plugin-css-imports": {
       "name": "@prpl/plugin-css-imports",
-      "version": "0.2.8",
+      "version": "0.2.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"
@@ -54,7 +57,7 @@
     },
     "../../packages/plugin-html-imports": {
       "name": "@prpl/plugin-html-imports",
-      "version": "0.2.8",
+      "version": "0.2.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"
@@ -62,7 +65,7 @@
     },
     "../../packages/plugin-rss": {
       "name": "@prpl/plugin-rss",
-      "version": "0.2.7",
+      "version": "0.2.10",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"
@@ -70,7 +73,7 @@
     },
     "../../packages/plugin-sitemap": {
       "name": "@prpl/plugin-sitemap",
-      "version": "0.1.8",
+      "version": "0.1.11",
       "license": "MIT",
       "peerDependencies": {
         "@prpl/core": ">=0.2.0"
@@ -78,7 +81,7 @@
     },
     "../../packages/server": {
       "name": "@prpl/server",
-      "version": "0.1.7",
+      "version": "0.1.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1997,8 +2000,9 @@
     "@prpl/core": {
       "version": "file:../../packages/core",
       "requires": {
-        "@types/marked": "^2.0.4",
-        "marked": "^2.1.0"
+        "@types/marked": "^4.0.2",
+        "idb-keyval": "^6.1.0",
+        "marked": "^4.0.12"
       }
     },
     "@prpl/plugin-code-highlight": {


### PR DESCRIPTION
- Use indexed db instead of session storage to:
	- Avoid low storage limits
	- Persist data between sessions and tabs
	- Reduce extra requests that hit the browser cache
- Add cache invalidation via build id meta tag

Todo
- [x] Docs
- [ ] Tests